### PR TITLE
Adding gymnasiumhilversum

### DIFF
--- a/lib/domains/com/gymnasiumhilversum.txt
+++ b/lib/domains/com/gymnasiumhilversum.txt
@@ -1,0 +1,2 @@
+Gemeentelijk Gymnasium Hilversum
+.group


### PR DESCRIPTION
This is a high school: https://www.gymnasiumhilversum.nl/
The programming is in lesson(start programmeerklas): https://www.gymnasiumhilversum.nl/storage/file/51b2f398-e9f8-42c6-a78e-1357c86bfde9/aristoteles_programma_per_leerjaar_v2-(1).pdf

While the school website domain is ".nl", our email system is using the ".com".

Here is the school email mailbox showing the ".com" extension:
<img width="1061" height="671" alt="image" src="https://github.com/user-attachments/assets/a88c2d4b-c455-466b-a7b9-06538b633f5a" />

The ".nl" was approved in this commit: https://github.com/JetBrains/swot/pull/27679/commits/65f555c93495e4154423f77435747cbe12e174ef